### PR TITLE
Allow property-info v5 as dep 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": ">=7.1",
         "ext-json": "*",
         "phpunit/phpunit": "^7.0|^8.0",
-        "symfony/property-info": "^4.3"
+        "symfony/property-info": "^4.3|^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",

--- a/src/Extractor/DocBlockMagicExtractor.php
+++ b/src/Extractor/DocBlockMagicExtractor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Radebatz\PropertyInfoExtras\Extractor;
 
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\Method;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -52,11 +53,12 @@ class DocBlockMagicExtractor implements PropertyListExtractorInterface, Property
 
         $properties = [];
 
-        /** @var DocBlock\Tags\Method $method */
+        /** @var Method $method */
         foreach ($docBlock->getTagsByName('method') as $method) {
-            if ($method->isStatic()) {
+            if (!($method instanceof Method) || $method->isStatic()) {
                 continue;
             }
+
             $propertyName = $this->getPropertyName($method->getMethodName());
             if ($propertyName && !preg_match('/^[A-Z]{2,}/', $propertyName)) {
                 $propertyName = lcfirst($propertyName);
@@ -86,6 +88,10 @@ class DocBlockMagicExtractor implements PropertyListExtractorInterface, Property
 
         /** @var DocBlock\Tags\Method $method */
         foreach ($docBlock->getTagsByName('method') as $method) {
+            if (!($method instanceof Method)) {
+                continue;
+            }
+
             $methodName = $method->getMethodName();
 
             foreach ($this->dockBlockCache->getMutatorPrefixes() as $mutatorPrefix) {


### PR DESCRIPTION
* Allows `property-info` v5 as valid dependency and as
* Code changes to deal with changed behaviour in `phpDocumentor` v5.
  phpDcumentator tag lookups may return `InvalidTag` instances so its good to make sure we deal with the real thing.